### PR TITLE
pycbc_live: add Virgo as followup detector

### DIFF
--- a/O2/pycbc_live/run.sh
+++ b/O2/pycbc_live/run.sh
@@ -33,7 +33,7 @@ pycbc_live \
 --highpass-reduction 200 \
 --psd-samples 30 \
 --max-psd-abort-distance 300 \
---min-psd-abort-distance 10 \
+--min-psd-abort-distance 20 \
 --psd-abort-difference .15 \
 --psd-recalculate-difference .01 \
 --psd-inverse-length 3.5 \

--- a/O2/pycbc_live/run.sh
+++ b/O2/pycbc_live/run.sh
@@ -17,6 +17,7 @@ pycbc_live \
 --sample-rate 2048 \
 --enable-bank-start-frequency \
 --low-frequency-cutoff 20 \
+--max-length 128 \
 --approximant "SPAtmplt:mtotal<4" "SEOBNRv4_ROM:else" \
 --chisq-bins "0.9 * get_freq('fSEOBNRv4Peak',params.mass1,params.mass2,params.spin1z,params.spin2z) ** (2.0 / 3.0)" \
 --snr-abort-threshold 500 \
@@ -32,20 +33,20 @@ pycbc_live \
 --highpass-reduction 200 \
 --psd-samples 30 \
 --max-psd-abort-distance 300 \
---min-psd-abort-distance 20 \
+--min-psd-abort-distance 10 \
 --psd-abort-difference .15 \
 --psd-recalculate-difference .01 \
 --psd-inverse-length 3.5 \
 --psd-segment-length 4 \
 --trim-padding .5 \
 --store-psd \
---state-channel H1:GDS-CALIB_STATE_VECTOR L1:GDS-CALIB_STATE_VECTOR \
---channel-name H1:GDS-CALIB_STRAIN L1:GDS-CALIB_STRAIN \
---data-quality-channel H1:DMT-DQ_VECTOR L1:DMT-DQ_VECTOR \
---data-quality-flags OMC_DCPD_ADC_OVERFLOW ETMY_ESD_DAC_OVERFLOW \
+--state-channel H1:GDS-CALIB_STATE_VECTOR L1:GDS-CALIB_STATE_VECTOR V1:DQ_ANALYSIS_STATE_VECTOR \
+--channel-name H1:GDS-CALIB_STRAIN L1:GDS-CALIB_STRAIN V1:Hrec_hoft_16384Hz \
+--data-quality-channel H1:DMT-DQ_VECTOR L1:DMT-DQ_VECTOR V1:DQ_ANALYSIS_STATE_VECTOR \
+--data-quality-flags H1:OMC_DCPD_ADC_OVERFLOW,ETMY_ESD_DAC_OVERFLOW L1:OMC_DCPD_ADC_OVERFLOW,ETMY_ESD_DAC_OVERFLOW V1:VIRGO_GOOD_DQ \
 --data-quality-padding 1.0 \
---increment-update-cache H1:/dev/shm/llhoft/H1/ L1:/dev/shm/llhoft/L1/ \
---frame-src H1:/dev/shm/llhoft/H1/* L1:/dev/shm/llhoft/L1/* \
+--increment-update-cache H1:/dev/shm/llhoft/H1/ L1:/dev/shm/llhoft/L1/ V1:/dev/shm/llhoft/V1/ \
+--frame-src H1:/dev/shm/llhoft/H1/* L1:/dev/shm/llhoft/L1/* V1:/dev/shm/llhoft/V1/* \
 --processing-scheme cpu:4 \
 --fftw-input-float-wisdom-file float_02.wis \
 --fftw-input-double-wisdom-file double_02.wis \
@@ -71,4 +72,6 @@ pycbc_live \
 --enable-production-gracedb-upload \
 --enable-gracedb-upload \
 --enable-single-detector-upload \
---round-start-time 4
+--round-start-time 4 \
+--upload-snr-series \
+--followup-detectors V1


### PR DESCRIPTION
This adds Virgo as a followup detector to PyCBC Live. Requires PyCBC commit b60402af9882b31236d79f93689d91f32c49bc42 or later.

Still testing, opening for consideration. In particular I would like opinions on `--max-length` (I used 64 in my tests, I have not verified if 128 is enough) and `--min-psd-abort-distance` (is that horizon or sensemon?).