### PR TITLE
Adding non-science running details

### DIFF
--- a/O2/non_science_analysis/README.md
+++ b/O2/non_science_analysis/README.md
@@ -5,7 +5,7 @@ These are generated in the following way.
    * One using ANALYSIS READY as the science segment
    * One using ODC-READY as the science segment (`ODC-MASTER_OBS_READY:1`)
    * One using LOCKED as the science segment (`DMT-GRD_ISC_LOCK_NOMINAL:1`)
- * The runme.py script then uses the segment files that this produces as input to generate analysis segments. This basically works in the following way
+ * The generate_non_science_segments.py script then uses the segment files that this produces as input to generate analysis segments. This basically works in the following way
    * Identify times in both H1 and L1 that are ODC-READY but not ANALYSIS READY
    * Take the union of those lists with times when both H1 and L1 are ODC-READY.
    * This is then times which become coincident after including ODC-READY
@@ -13,5 +13,5 @@ These are generated in the following way.
    * This allows short periods of ODC-READY within longer lock stretches to be analysed, but does mean we include some ANALYSIS READY + ANALYSIS READY times.
  * This process is then repeated with LOCKED and ODC-READY
  * The resulting segment files for H1 and L1 are then placed in the expected output location for a PyCBC coinc run.
- * A workflow is then generated with the "Rerun pre-existing segment files" option set to false (check the log to make sure segment files are being reused!!!)
+ * A workflow is then generated with the "Rerun pre-existing segment files" option set to false (check the log to make sure segment files are being reused!)
  * Then it is submitted. Two runs.

--- a/O2/non_science_analysis/README.md
+++ b/O2/non_science_analysis/README.md
@@ -1,0 +1,17 @@
+This directory contains files for doing analysis on non-SCIENCE data.
+These are generated in the following way.
+
+ * Setup 3 runs
+   * One using ANALYSIS READY as the science segment
+   * One using ODC-READY as the science segment (`ODC-MASTER_OBS_READY:1`)
+   * One using LOCKED as the science segment (`DMT-GRD_ISC_LOCK_NOMINAL:1`)
+ * The runme.py script then uses the segment files that this produces as input to generate analysis segments. This basically works in the following way
+   * Identify times in both H1 and L1 that are ODC-READY but not ANALYSIS READY
+   * Take the union of those lists with times when both H1 and L1 are ODC-READY.
+   * This is then times which become coincident after including ODC-READY
+   * Segments are then protracted by 512s and we again take the union with ODC READY, now individually in each detector.
+   * This allows short periods of ODC-READY within longer lock stretches to be analysed, but does mean we include some ANALYSIS READY + ANALYSIS READY times.
+ * This process is then repeated with LOCKED and ODC-READY
+ * The resulting segment files for H1 and L1 are then placed in the expected output location for a PyCBC coinc run.
+ * A workflow is then generated with the "Rerun pre-existing segment files" option set to false (check the log to make sure segment files are being reused!!!)
+ * Then it is submitted. Two runs.

--- a/O2/non_science_analysis/generate_non_science_segments.py
+++ b/O2/non_science_analysis/generate_non_science_segments.py
@@ -1,0 +1,80 @@
+import copy
+from pycbc.workflow import SegFile
+
+ldas_segs = {}
+locked_segs = {}
+odc_segs = {}
+
+for ifo in ['H1','L1']:
+    ldas = '{}-LDAS_SEGMENTS.xml'.format(ifo)
+    locked = '{}-LOCKED_SEGMENTS.xml'.format(ifo)
+    odc = '{}-ODCREADY_SEGMENTS.xml'.format(ifo)
+    ldas_file = SegFile.from_segment_xml(ldas)
+    locked_file = SegFile.from_segment_xml(locked)
+    odc_file = SegFile.from_segment_xml(odc)
+    ldas_segs[ifo] = ldas_file.return_union_seglist()
+    locked_segs[ifo] = locked_file.return_union_seglist()
+    odc_segs[ifo] = odc_file.return_union_seglist()
+
+print abs(ldas_segs['H1']), abs(ldas_segs['L1'])
+# Case 1: Nominal, but not READY
+nominal_h = odc_segs['H1'] - ldas_segs['H1']
+print abs(odc_segs['H1'])
+print abs(nominal_h)
+subnominal_h = locked_segs['H1'] - odc_segs['H1']
+print abs(subnominal_h)
+
+nominal_l = odc_segs['L1'] - ldas_segs['L1']
+print abs(nominal_l)
+subnominal_l = locked_segs['L1'] - odc_segs['L1']
+print abs(subnominal_l)
+
+nominal_both = nominal_h | nominal_l
+nominal_both.coalesce()
+print abs(nominal_both)
+# Remove short segments
+#nominal_both.protract(512)
+nominal_both.coalesce()
+print abs(nominal_both)
+nominal_both = nominal_both & odc_segs['H1']
+nominal_both = nominal_both & odc_segs['L1']
+print abs(nominal_both)
+nominal_h1 = copy.deepcopy(nominal_both)
+nominal_h1.protract(512)
+nominal_h1 = nominal_h1 & odc_segs['H1']
+
+print "H1 NOMINAL:", abs(nominal_h1), len(nominal_h1)
+nom_h1_file = SegFile.from_segment_list('NOMINAL_SCIENCE', nominal_h1, 'NOMINAL_SCIENCE', 'H1', extension='.xml', directory='.')
+#nom_h1_file.to_segment_xml()
+
+nominal_l1 = copy.deepcopy(nominal_both)
+nominal_l1.protract(512)
+nominal_l1 = nominal_l1 & odc_segs['L1']
+
+print "L1 NOMINAL:", abs(nominal_l1)
+nom_l1_file = SegFile.from_segment_list('NOMINAL_SCIENCE', nominal_l1, 'NOMINAL_SCIENCE', 'L1', extension='.xml', directory='.')
+#nom_l1_file.to_segment_xml()
+
+print
+
+subnominal_both = subnominal_h | subnominal_l
+subnominal_both.coalesce()
+print abs(subnominal_both)
+subnominal_both = subnominal_both & locked_segs['H1']
+subnominal_both = subnominal_both & locked_segs['L1']
+print abs(subnominal_both)
+subnominal_h1 = copy.deepcopy(subnominal_both)
+subnominal_h1.protract(512)
+subnominal_h1 = subnominal_h1 & locked_segs['H1']
+
+print "H1 SUBNOMINAL", abs(subnominal_h1)
+subnom_h1_file = SegFile.from_segment_list('SUBNOMINAL_SCIENCE', subnominal_h1, 'SUBNOMINAL_SCIENCE', 'H1', extension='.xml', directory='.')
+#nom_h1_file.to_segment_xml()
+
+subnominal_l1 = copy.deepcopy(subnominal_both)
+subnominal_l1.protract(512)
+subnominal_l1 = subnominal_l1 & locked_segs['L1']
+
+print "L1 SUBNOMINAL", abs(subnominal_l1)
+subnom_l1_file = SegFile.from_segment_list('SUBNOMINAL_SCIENCE', subnominal_l1, 'SUBNOMINAL_SCIENCE', 'L1', extension='.xml', directory='.')
+#nom_l1_file.to_segment_xml()


### PR DESCRIPTION
@duncan-brown Here I resurrect the pull request to add non-science mode running details and instructions.

Can we iterate on this a little before kicking this up. Specifically I would like to add generation of the CAT_2 flags, that would be needed to remove SCIENCE times that are included in the analysis due to protracting segments to ensure that short non-SCIENCE times attached to longer SCIENCE times get analysed.

... Or we can discuss what is needed to do that and have you guys take this on, it's no difference on my end.