### PR TITLE
Get the statmap file from CVMFS

### DIFF
--- a/O2/pipeline/analysis.ini
+++ b/O2/pipeline/analysis.ini
@@ -233,7 +233,7 @@ ranking-statistic = phasetd_exp_fit_stat_sgveto
 
 ; Parameters to reproduce this file available at
 ; https://git.ligo.org/ligo-cbc/pycbc-software/blob/c2fc41b3c32dbaa2fe859b0d5929b050c01c2b91/statistic-files/v1/make_h1l1_phase_time_amp_v1.sh
-statistic-files = https://git.ligo.org/ligo-cbc/pycbc-software/raw/710a51f4770cbba77f61dfb798472bebe6c43d38/statistic-files/v1/H1L1-PHASE_TIME_AMP_v1.hdf
+statistic-files = file://localhost/cvmfs/oasis.opensciencegrid.org/ligo/sw/pycbc/statistic-files/v1/H1L1-PHASE_TIME_AMP_v1.hdf
 
 [coinc-full]
 ; time-slide interval in seconds


### PR DESCRIPTION
Get the statmap file from CVMFS rather than git.ligo.org to prevent overloading the GitLab server.