### PR TITLE
adjust splittable-num-banks to reduce job runtimes by a factor of 4

### DIFF
--- a/O2/pipeline/analysis.ini
+++ b/O2/pipeline/analysis.ini
@@ -50,7 +50,7 @@ splittable-exe-tag = splitbank
 
 [workflow-splittable-full_data]
 ; empirically tuned on O2 OSG runtime data to give runtimes between 15 mins and 10 hours, mostly ~6 hours
-splittable-num-banks = 16
+splittable-num-banks = 32
 
 [workflow-splittable-injections]
 ; empirically tuned on O2 OSG runtime data to give runtimes between a few mins and ~10 hours, mostly >30 minutes

--- a/O2/pipeline/analysis.ini
+++ b/O2/pipeline/analysis.ini
@@ -49,12 +49,12 @@ splittable-method = IN_WORKFLOW
 splittable-exe-tag = splitbank
 
 [workflow-splittable-full_data]
-; empirically tuned on O1 data to give runtimes between 1 and 10 hours
-splittable-num-banks = 8
+; empirically tuned on O2 OSG runtime data to give runtimes between 15 mins and 10 hours, mostly ~6 hours
+splittable-num-banks = 16
 
 [workflow-splittable-injections]
-; empirically tuned on O1 data to give runtimes between a few mins and 10 hours
-splittable-num-banks = 2
+; empirically tuned on O2 OSG runtime data to give runtimes between a few mins and ~10 hours, mostly >30 minutes
+splittable-num-banks = 8
 
 [workflow-matchedfilter]
 ; http://ligo-cbc.github.io/pycbc/releases/v1.2.0/html/workflow/matched_filter.html


### PR DESCRIPTION
@duncan-brown, @bbockelm, and I observed in the OSG accounting data that we have lots of jobs running for >12 hours, beyond which we see a big uptick in badput (aka job re-runs due to preemption).  This patch reduces the job runtime by a factor of 4 in order to reduce badput without making the average job runtime too short.

This should result in a substantial (10-20%?) increase in overall workflow throughput, and possibly a reduction in total workflow wall-clock time (aka time to result).