### PR TITLE
Add a section to set number of hierarchical removals

### DIFF
--- a/O2/pipeline/analysis.ini
+++ b/O2/pipeline/analysis.ini
@@ -84,6 +84,10 @@ parallelization-factor = 10
 ; not clear if this has any meaning now - FIXME
 gating-method = PREGENERATED_FILE
 
+[workflow-results]
+; number of levels of event hierarchical removal to perform
+max-hierarchical-removal = 5
+
 [llwadd]
 
 [segments_from_cats]
@@ -249,6 +253,9 @@ timeslide-interval = ${coinc-full|timeslide-interval}
 cluster-window = ${statmap|cluster-window}
 ; keep only coincs with a stat above specified value in injection little-dog analysis
 loudest-keep-value = 8.5
+
+[statmap]
+max-hierarchical-removal = ${workflow-results|max-hierarchical-removal}
 
 [statmap&statmap_inj]
 ; time window (in seconds) used to remove triggers around zero-lag coincidences


### PR DESCRIPTION
The user should set ``max-hierarchical-removal`` in the ``[workflow-results]`` section and then this is propagated to statmap. The values is used in ``pycbc_make_coinc_search_workflow`` to generate ``max-hierarchical-removal`` invocations of the various plotting codes.