### PR TITLE
Add GPS ini file and gating ini for analysis 20

### DIFF
--- a/O2/pipeline/gating.ini
+++ b/O2/pipeline/gating.ini
@@ -1,0 +1,5 @@
+; Last commit of gating file
+[workflow-gating]
+gating-method = PREGENERATED_FILE
+gating-file-h1 = https://git.ligo.org/detchar/veto-definitions/raw/0bc76d44ae5a03ee30e2f10b2c4962528413bfe2/cbc/O2/H1-GATES-1163203217-24537601.txt
+gating-file-l1 = https://git.ligo.org/detchar/veto-definitions/raw/0bc76d44ae5a03ee30e2f10b2c4962528413bfe2/cbc/O2/L1-GATES-1163203217-24537601.txt

--- a/O2/pipeline/gating_analysis_20.ini
+++ b/O2/pipeline/gating_analysis_20.ini
@@ -1,0 +1,5 @@
+; Gating file used in analysis 20
+[workflow-gating]
+gating-method = PREGENERATED_FILE
+gating-file-h1 = https://git.ligo.org/detchar/veto-definitions/raw/5449edf6bf96fbd428add6551a51397bc5777f11/cbc/O2/H1-GATES-1185937218-1803600.txt
+workflow-gating:gating-file-l1 = https://git.ligo.org/detchar/veto-definitions/raw/5449edf6bf96fbd428add6551a51397bc5777f11/cbc/O2/L1-GATES-1185937218-1803600.txt

--- a/O2/pipeline/gating_analysis_20.ini
+++ b/O2/pipeline/gating_analysis_20.ini
@@ -1,5 +1,0 @@
-; Gating file used in analysis 20
-[workflow-gating]
-gating-method = PREGENERATED_FILE
-gating-file-h1 = https://git.ligo.org/detchar/veto-definitions/raw/5449edf6bf96fbd428add6551a51397bc5777f11/cbc/O2/H1-GATES-1185937218-1803600.txt
-workflow-gating:gating-file-l1 = https://git.ligo.org/detchar/veto-definitions/raw/5449edf6bf96fbd428add6551a51397bc5777f11/cbc/O2/L1-GATES-1185937218-1803600.txt

--- a/O2/pipeline/gps_times_O2_analysis_20.ini
+++ b/O2/pipeline/gps_times_O2_analysis_20.ini
@@ -1,0 +1,18 @@
+; PyCBC configuration for CBC searches on O2 data
+
+[workflow]
+; http://ligo-cbc.github.io/pycbc/releases/v1.7.11/html/workflow.html
+
+; 2017-08-05 03:00:00 UTC
+start-time = 1185937218
+
+; 2017-08-13 02:00:00
+end-time = 1186624818
+
+[workflow-segments]
+; http://ligo-cbc.github.io/pycbc/releases/v1.7.11/html/workflow/segments.html
+segments-veto-definer-url = https://git.ligo.org/detchar/veto-definitions/raw/5449edf6bf96fbd428add6551a51397bc5777f11/cbc/O2/H1L1-HOFT_C00_O2_CBC.xml
+
+[results_page]
+analysis-title = "PyCBC offline search"
+analysis-subtitle = "O2 Analysis 20  v1.7.11"


### PR DESCRIPTION
These are the gps times used in analysis 20. Additionally is a gating ini file for analysis 20. I've committed them separately in case people don't want to use the gating configs. Of course they could always `config-delete`. Let me know if you'd rather have them in one file.