### PR TITLE
Clarify Order of Operations in Analysis ini file

### DIFF
--- a/O2/pipeline/analysis.ini
+++ b/O2/pipeline/analysis.ini
@@ -132,7 +132,7 @@ psd-segment-length = 16
 psd-segment-stride = 8
 psd-inverse-length = 16
 ; 512s PSD length given by:
-; (psd-segment-length + psd-num-segments - 1 * psd-segment-stride)
+; 512s = psd-segment-length + (psd-num-segments - 1) * psd-segment-stride
 psd-num-segments = 63
 
 ; Autogating options

--- a/O2clean/pipeline/analysis.ini
+++ b/O2clean/pipeline/analysis.ini
@@ -132,7 +132,7 @@ psd-segment-length = 16
 psd-segment-stride = 8
 psd-inverse-length = 16
 ; 512s PSD length given by:
-; (psd-segment-length + psd-num-segments - 1 * psd-segment-stride)
+; 512s = psd-segment-length + (psd-num-segments - 1) * psd-segment-stride
 psd-num-segments = 63
 
 ; Autogating options

--- a/O3/pipeline/analysis.ini
+++ b/O3/pipeline/analysis.ini
@@ -132,7 +132,7 @@ psd-segment-length = 16
 psd-segment-stride = 8
 psd-inverse-length = 16
 ; 512s PSD length given by:
-; (psd-segment-length + psd-num-segments - 1 * psd-segment-stride)
+; 512s = psd-segment-length + (psd-num-segments - 1) * psd-segment-stride
 psd-num-segments = 63
 
 ; Autogating options

--- a/O3exp/pipeline/analysis.ini
+++ b/O3exp/pipeline/analysis.ini
@@ -132,7 +132,7 @@ psd-segment-length = 16
 psd-segment-stride = 8
 psd-inverse-length = 16
 ; 512s PSD length given by:
-; (psd-segment-length + psd-num-segments - 1 * psd-segment-stride)
+; 512s = psd-segment-length + (psd-num-segments - 1) * psd-segment-stride
 psd-num-segments = 63
 
 ; Autogating options


### PR DESCRIPTION
The current order of operations in the comments won't give you 512 second PSD lengths.

This could potentially be confusing to new users.

Currently it states
`(psd-segment-length + psd-num-segments - 1 * psd-segment-stride)`
512s = 16s + 63 - 1*8s, which would give you something wrong and in non-sensical units

change this to:
`512s = psd-segment-length + (psd-num-segments - 1) * psd-segment-stride`
512s = 16s + (63-1)*8s, which gives the correct answer