### PR TITLE
Need to add compatibility option for ligolw_add

### DIFF
--- a/O3exp/pipeline/analysis.ini
+++ b/O3exp/pipeline/analysis.ini
@@ -91,6 +91,7 @@ gating-method = PREGENERATED_FILE
 max-hierarchical-removal = 5
 
 [llwadd]
+ilwdchar-compat =
 
 [segments_from_cats]
 


### PR DESCRIPTION
Looks like the ligolw library is moving and we're currently in the middle of this. For now this is the solution, but things will probably change again at some point.