### PR TITLE
Add plot_qscan into executables

### DIFF
--- a/O3exp/pipeline/executables.ini
+++ b/O3exp/pipeline/executables.ini
@@ -40,6 +40,7 @@ plot_coinc_snrchi = ${which:pycbc_page_coinc_snrchi}
 plot_foundmissed = ${which:pycbc_page_foundmissed}
 plot_gating = ${which:pycbc_plot_gating}
 plot_hist = ${which:pycbc_plot_hist}
+plot_qscan = ${which:pycbc_plot_qscan}
 plot_range = ${which:pycbc_plot_range}
 plot_segments = ${which:pycbc_page_segments}
 plot_sensitivity = ${which:pycbc_page_sensitivity}


### PR DESCRIPTION
Not sure why this was missing, but it's needed for the minifollowups