### PR TITLE
Changes needed for background coinc followup

### DIFF
--- a/O3exp/pipeline/plotting.ini
+++ b/O3exp/pipeline/plotting.ini
@@ -25,7 +25,12 @@ num-events = 10
 subsection-suffix = with_ifar_lt_1_year
 
 [foreground_minifollowup]
+
+[foreground_minifollowup-foreground]
 analysis-category = foreground
+
+[foreground_minifollowup-background]
+analysis-category = background
 
 [singles_minifollowup]
 ranking-statistic = newsnr_sgveto


### PR DESCRIPTION
Note that usually would use background_exc for background_coinc followup but this isn't currently given in the output of add_statmap